### PR TITLE
Fix source, repo links in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /Manifest.toml
+/docs/src/**.md
+/docs/build/

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,7 @@ let orgconverted = 0
                 o -> sprint(markdown, o) |>
                 html2utf8entity_dirty |>
                 s -> replace(s, r"\.org]" => ".md]") |>
+                m -> string("```@meta\nEditURL=\"$(basename(orgfile))\"\n```\n\n", m) |>
                 m -> write(mdfile, m)
         end
         orgconverted += length(orgfiles)
@@ -41,7 +42,6 @@ makedocs(;
         "Reference" => "reference.md",
         "Quick Reference Guide" => "quickref.md",
     ],
-    repo="https://github.com/tecosaur/DataToolkit.jl/blob/{commit}{path}#L{line}",
     sitename="DataToolkit.jl",
     authors = "tecosaur and contributors: https://github.com/tecosaur/DataToolkit.jl/graphs/contributors",
     warnonly = [:missing_docs],


### PR DESCRIPTION
Just something I noticed when browsing the docs:

1. Fixes the source links for the org file by adding the correct `EditURL` at-meta blocks to the `.md` files generated from the `.org` files.
2. Removes the `repo` keyword so that Documenter would pick it up automatically, and therefore generate the `GitHub` link to the repo.

![image](https://github.com/tecosaur/DataToolkit.jl/assets/147757/cffadc84-240b-430a-93a2-412d69810694)

vs the current

![image](https://github.com/tecosaur/DataToolkit.jl/assets/147757/7c104013-33d4-41d7-a118-823ff5cb994c)

Unrelatedly, I also added the generated docs files into `.gitignore`, though happy to revert that if that's not what you want.
